### PR TITLE
課題,ジャンルの順序をドラッグアンドドロップで更新

### DIFF
--- a/backend/controller/task.go
+++ b/backend/controller/task.go
@@ -80,25 +80,35 @@ func GetTask(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"task": taskResponse})
 }
 
-type TaskRequest struct {
-	Title        string `json:"Title" binding:"required"`
-	Text         string `json:"Text" binding:"required"`
-	GenreID      uint   `json:"GenreID" binding:"required"`
-	DisplayOrder int    `json:"DisplayOrder" binding:"required"`
+type createTaskRequest struct {
+	Title   string `json:"Title" binding:"required"`
+	Text    string `json:"Text" binding:"required"`
+	GenreID uint   `json:"GenreID" binding:"required"`
 }
 
 func CreateTask(c *gin.Context) {
-	var request TaskRequest
+	var request createTaskRequest
 
 	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
+	// 同じジャンルの課題の最大DisplayOrderを取得
+	var maxDisplayOrder int
+	if err := database.DB.Model(&models.Task{}).
+		Joins("JOIN genre_tasks ON tasks.id = genre_tasks.task_id").
+		Where("genre_tasks.genre_id = ?", request.GenreID).
+		Select("COALESCE(MAX(tasks.display_order), 0)").
+		Scan(&maxDisplayOrder).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
 	task := models.Task{
 		Title:        request.Title,
 		Text:         request.Text,
-		DisplayOrder: request.DisplayOrder,
+		DisplayOrder: maxDisplayOrder + 1,
 	}
 
 	if err := database.DB.Create(&task).Error; err != nil {
@@ -117,8 +127,14 @@ func CreateTask(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "タスクが正常に作成されました"})
 }
 
+type updateTaskRequest struct {
+	Title   string `json:"Title" binding:"required"`
+	Text    string `json:"Text" binding:"required"`
+	GenreID uint   `json:"GenreID" binding:"required"`
+}
+
 func UpdateTask(c *gin.Context) {
-	var request TaskRequest
+	var request updateTaskRequest
 	id := c.Param("id")
 
 	var task models.Task
@@ -132,23 +148,17 @@ func UpdateTask(c *gin.Context) {
 		return
 	}
 
-	task.Title = request.Title
-	task.Text = request.Text
-	task.DisplayOrder = request.DisplayOrder
-
-	if err := database.DB.Save(&task).Error; err != nil {
+	// タスクの更新
+	if err := database.DB.Model(&task).Updates(models.Task{
+		Title: request.Title,
+		Text:  request.Text,
+	}).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	var genreTask models.GenreTask
-	if err := database.DB.Where("task_id = ?", task.ID).First(&genreTask).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	genreTask.GenreID = request.GenreID
-	if err := database.DB.Save(&genreTask).Error; err != nil {
+	// ジャンルタスクの更新
+	if err := database.DB.Model(&models.GenreTask{}).Where("task_id = ?", task.ID).Update("genre_id", request.GenreID).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -34,6 +34,7 @@ func setupRouter() *gin.Engine {
 	r.GET("/genres/:id", controller.GetGenre)
 	r.PATCH("/genres/:id", controller.UpdateGenre)
 	r.DELETE("/genres/:id", controller.DeleteGenre)
+	r.PATCH("/genres/order", controller.UpdateGenreOrders)
 
 	r.GET("/genre-publications", controller.GetGenrePublications)
 	r.PATCH("/genre-publications", controller.UpdateGenrePublications)

--- a/backend/main.go
+++ b/backend/main.go
@@ -27,6 +27,7 @@ func setupRouter() *gin.Engine {
 	r.GET("/tasks/:id", controller.GetTask)
 	r.PATCH("/tasks/:id", controller.UpdateTask)
 	r.DELETE("/tasks/:id", controller.DeleteTask)
+	r.PATCH("/tasks/order", controller.UpdateTaskOrders)
 
 	r.GET("/genres", controller.GetGenres)
 	r.POST("/genres", controller.CreateGenre)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,9 @@
     "prepare": "cd .. && husky frontend/.husky"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "next": "14.2.14",
     "react": "^18",
     "react-dom": "^18"

--- a/frontend/src/app/admin/genres/edit/[id]/page.tsx
+++ b/frontend/src/app/admin/genres/edit/[id]/page.tsx
@@ -9,9 +9,9 @@ export default async function EditGenrePage({
 }) {
   const genre = await getGenre(parseInt(params.id))
 
-  const handleUpdate = async (name: string, displayOrder: number) => {
+  const handleUpdate = async (name: string) => {
     'use server'
-    await updateGenre(genre.ID, name, displayOrder)
+    await updateGenre(genre.ID, name)
     revalidatePath('/admin/genres', 'page')
     revalidatePath('/admin/genres/publications', 'page')
   }

--- a/frontend/src/app/admin/genres/new/page.tsx
+++ b/frontend/src/app/admin/genres/new/page.tsx
@@ -4,9 +4,9 @@ import { revalidatePath } from 'next/cache'
 import type React from 'react'
 
 const NewGenrePage: React.FC = () => {
-  async function handleCreateGenre(name: string, displayOrder: number) {
+  async function handleCreateGenre(name: string) {
     'use server'
-    await createGenre(name, displayOrder)
+    await createGenre(name)
     revalidatePath('/admin/genres')
     revalidatePath('/admin/genres/publications')
   }

--- a/frontend/src/app/admin/genres/page.tsx
+++ b/frontend/src/app/admin/genres/page.tsx
@@ -1,7 +1,8 @@
-import GenreTable from '@/app/components/GenreTable'
-import { deleteGenre, getGenres } from '@/lib/backend/genre'
+import GenreEditor from '@/app/components/GenreEditor'
+import { deleteGenre, getGenres, updateGenreOrders } from '@/lib/backend/genre'
+import type { GenreOrder } from '@/lib/backend/types/genre'
 import { revalidatePath } from 'next/cache'
-import Link from 'next/link'
+import type React from 'react'
 
 const handleDeleteGenre = async (genreId: number) => {
   'use server'
@@ -10,31 +11,26 @@ const handleDeleteGenre = async (genreId: number) => {
   revalidatePath('/admin/genres/publications')
 }
 
-export default async function GenresPage() {
+const handleUpdateGenreOrders = async (genreOrders: GenreOrder[]) => {
+  'use server'
+  await updateGenreOrders(genreOrders)
+  revalidatePath('/admin/genres')
+  revalidatePath('/admin/genres/publications')
+  revalidatePath('/admin/tasks')
+}
+
+const GenresPage: React.FC = async () => {
   const genres = await getGenres()
 
   return (
     <div className="mx-auto max-w-4xl py-8">
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-          ジャンル一覧
-        </h1>
-        <div className="space-x-2">
-          <Link
-            href="/admin/genres/publications"
-            className="rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600 dark:bg-green-600 dark:hover:bg-green-700"
-          >
-            公開設定
-          </Link>
-          <Link
-            href="/admin/genres/new"
-            className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700"
-          >
-            新規ジャンル作成
-          </Link>
-        </div>
-      </div>
-      <GenreTable genres={genres} handleDeleteGenre={handleDeleteGenre} />
+      <GenreEditor
+        genres={genres}
+        handleDeleteGenre={handleDeleteGenre}
+        handleUpdateGenreOrders={handleUpdateGenreOrders}
+      />
     </div>
   )
 }
+
+export default GenresPage

--- a/frontend/src/app/admin/tasks/edit/[id]/page.tsx
+++ b/frontend/src/app/admin/tasks/edit/[id]/page.tsx
@@ -11,14 +11,9 @@ export default async function EditTaskPage({
   const task = await getTask(parseInt(params.id))
   const genres = await getGenres()
 
-  const handleUpdate = async (
-    title: string,
-    text: string,
-    genreId: number,
-    displayOrder: number,
-  ) => {
+  const handleUpdate = async (title: string, text: string, genreId: number) => {
     'use server'
-    await updateTask(task.ID, title, text, genreId, displayOrder)
+    await updateTask(task.ID, title, text, genreId)
     revalidatePath('/admin/tasks')
   }
 

--- a/frontend/src/app/admin/tasks/new/page.tsx
+++ b/frontend/src/app/admin/tasks/new/page.tsx
@@ -11,10 +11,9 @@ const NewTaskPage: React.FC = async () => {
     title: string,
     text: string,
     genreId: number,
-    displayOrder: number,
   ) {
     'use server'
-    await createTask(title, text, genreId, displayOrder)
+    await createTask(title, text, genreId)
     revalidatePath('/admin/tasks')
   }
 

--- a/frontend/src/app/admin/tasks/page.tsx
+++ b/frontend/src/app/admin/tasks/page.tsx
@@ -1,7 +1,7 @@
-import TaskTable from '@/app/components/TaskTable'
-import { deleteTask, getTasks } from '@/lib/backend/task'
+import TaskEditor from '@/app/components/TaskEditor'
+import { deleteTask, getTasks, updateTaskOrders } from '@/lib/backend/task'
+import type { TaskOrder } from '@/lib/backend/types/task'
 import { revalidatePath } from 'next/cache'
-import Link from 'next/link'
 import type React from 'react'
 
 const handleDeleteTask = async (taskId: number) => {
@@ -10,23 +10,28 @@ const handleDeleteTask = async (taskId: number) => {
   revalidatePath('/admin/tasks', 'page')
 }
 
+const handleUpdateTaskOrders = async (taskOrders: TaskOrder[]) => {
+  'use server'
+  await updateTaskOrders(taskOrders)
+  revalidatePath('/admin/tasks', 'page')
+}
+
 const TasksPage: React.FC = async () => {
   const tasks = await getTasks()
+  const sortedTasks = tasks.sort((a, b) => {
+    if (a.GenreDisplayOrder !== b.GenreDisplayOrder) {
+      return a.GenreDisplayOrder - b.GenreDisplayOrder
+    }
+    return a.DisplayOrder - b.DisplayOrder
+  })
 
   return (
     <div className="mx-auto max-w-4xl py-8">
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-          課題一覧
-        </h1>
-        <Link
-          href="/admin/tasks/new"
-          className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700"
-        >
-          新規課題作成
-        </Link>
-      </div>
-      <TaskTable tasks={tasks} handleDeleteTask={handleDeleteTask} />
+      <TaskEditor
+        tasks={sortedTasks}
+        handleDeleteTask={handleDeleteTask}
+        handleUpdateTaskOrders={handleUpdateTaskOrders}
+      />
     </div>
   )
 }

--- a/frontend/src/app/components/GenreEditor.tsx
+++ b/frontend/src/app/components/GenreEditor.tsx
@@ -46,12 +46,23 @@ const GenreEditor: React.FC<GenreEditorProps> = ({
         </h1>
         <div className="flex gap-4">
           {isReordering ? (
-            <button
-              onClick={saveNewOrder}
-              className="rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600"
-            >
-              保存
-            </button>
+            <>
+              <button
+                onClick={saveNewOrder}
+                className="rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600"
+              >
+                保存
+              </button>
+              <button
+                onClick={() => {
+                  setIsReordering(false)
+                  setGenres(initialGenres) // 元の順序に戻す
+                }}
+                className="rounded bg-gray-500 px-4 py-2 text-white hover:bg-gray-600"
+              >
+                キャンセル
+              </button>
+            </>
           ) : (
             <>
               <button

--- a/frontend/src/app/components/GenreEditor.tsx
+++ b/frontend/src/app/components/GenreEditor.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import type { GenreOrder, GenreWithReference } from '@/lib/backend/types/genre'
+import Link from 'next/link'
+import type React from 'react'
+import { useEffect, useState } from 'react'
+import GenreTable from './GenreTable'
+
+interface GenreEditorProps {
+  genres: GenreWithReference[]
+  handleDeleteGenre: (genreId: number) => Promise<void>
+  handleUpdateGenreOrders: (genreOrders: GenreOrder[]) => Promise<void>
+}
+
+const GenreEditor: React.FC<GenreEditorProps> = ({
+  genres: initialGenres,
+  handleDeleteGenre,
+  handleUpdateGenreOrders,
+}) => {
+  const [isReordering, setIsReordering] = useState(false)
+  const [genres, setGenres] = useState(initialGenres)
+
+  useEffect(() => {
+    setGenres(initialGenres)
+  }, [initialGenres])
+
+  const saveNewOrder = async () => {
+    const genreOrders: GenreOrder[] = genres.map((genre, index) => ({
+      GenreID: genre.ID,
+      NewOrder: index + 1,
+    }))
+
+    await handleUpdateGenreOrders(genreOrders)
+    setIsReordering(false)
+  }
+
+  const handleGenresReorder = (reorderedGenres: GenreWithReference[]) => {
+    setGenres(reorderedGenres)
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          ジャンル一覧
+        </h1>
+        <div className="flex gap-4">
+          {isReordering ? (
+            <button
+              onClick={saveNewOrder}
+              className="rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600"
+            >
+              保存
+            </button>
+          ) : (
+            <>
+              <button
+                onClick={() => setIsReordering(true)}
+                className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+              >
+                順番変更
+              </button>
+              <Link
+                href="/admin/genres/publications"
+                className="rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600 dark:bg-green-600 dark:hover:bg-green-700"
+              >
+                公開設定
+              </Link>
+              <Link
+                href="/admin/genres/new"
+                className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700"
+              >
+                新規ジャンル作成
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+      <GenreTable
+        genres={genres}
+        handleDeleteGenre={handleDeleteGenre}
+        onGenresReorder={handleGenresReorder}
+        isReordering={isReordering}
+      />
+    </div>
+  )
+}
+
+export default GenreEditor

--- a/frontend/src/app/components/GenreForm.tsx
+++ b/frontend/src/app/components/GenreForm.tsx
@@ -7,21 +7,17 @@ import { useEffect, useState } from 'react'
 
 interface GenreFormProps {
   initialGenre?: Genre
-  onSubmit: (name: string, displayOrder: number) => Promise<void>
+  onSubmit: (name: string) => Promise<void>
 }
 
 const GenreForm: React.FC<GenreFormProps> = ({ initialGenre, onSubmit }) => {
   const router = useRouter()
   const [genreName, setGenreName] = useState(initialGenre?.Name || '')
-  const [displayOrder, setDisplayOrder] = useState(
-    initialGenre?.DisplayOrder || 0,
-  )
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (initialGenre) {
       setGenreName(initialGenre.Name)
-      setDisplayOrder(initialGenre.DisplayOrder)
     }
   }, [initialGenre])
 
@@ -33,13 +29,9 @@ const GenreForm: React.FC<GenreFormProps> = ({ initialGenre, onSubmit }) => {
       setError('ジャンル名を入力してください')
       return
     }
-    if (isNaN(displayOrder) || displayOrder < 0) {
-      setError('表示順は0以上の整数で入力してください')
-      return
-    }
 
     try {
-      await onSubmit(genreName, displayOrder)
+      await onSubmit(genreName)
       router.push('/admin/genres')
     } catch (error) {
       console.error('ジャンルの保存中にエラーが発生しました:', error)
@@ -73,29 +65,21 @@ const GenreForm: React.FC<GenreFormProps> = ({ initialGenre, onSubmit }) => {
           className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
         />
       </div>
-      <div>
-        <label
-          htmlFor="displayOrder"
-          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+      <div className="space-y-4">
+        <button
+          type="submit"
+          className="flex w-full justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:bg-indigo-700 dark:hover:bg-indigo-600"
         >
-          表示順
-        </label>
-        <input
-          type="number"
-          id="displayOrder"
-          name="displayOrder"
-          value={displayOrder}
-          onChange={(e) => setDisplayOrder(parseInt(e.target.value))}
-          required
-          className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
-        />
+          {initialGenre ? '更新' : '追加'}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push('/admin/genres')}
+          className="flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+        >
+          戻る
+        </button>
       </div>
-      <button
-        type="submit"
-        className="flex w-full justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:bg-indigo-700 dark:hover:bg-indigo-600"
-      >
-        {initialGenre ? '更新' : '追加'}
-      </button>
     </form>
   )
 }

--- a/frontend/src/app/components/GenreRow.tsx
+++ b/frontend/src/app/components/GenreRow.tsx
@@ -17,12 +17,19 @@ const GenreRow: React.FC<GenreRowProps> = ({
   onDelete,
   isReordering,
 }) => {
-  const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({ id: genre.ID })
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: genre.ID })
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
+    cursor: isReordering ? (isDragging ? 'grabbing' : 'grab') : 'default',
   }
 
   const handleDelete = async (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -38,7 +45,7 @@ const GenreRow: React.FC<GenreRowProps> = ({
       style={style}
       {...attributes}
       {...listeners}
-      className="hover:bg-gray-50 dark:hover:bg-gray-700"
+      className={isReordering ? 'hover:bg-gray-50 dark:hover:bg-gray-700' : ''}
     >
       <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
         {genre.Name}

--- a/frontend/src/app/components/GenreRow.tsx
+++ b/frontend/src/app/components/GenreRow.tsx
@@ -41,9 +41,6 @@ const GenreRow: React.FC<GenreRowProps> = ({
       className="hover:bg-gray-50 dark:hover:bg-gray-700"
     >
       <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
-        {genre.DisplayOrder}
-      </td>
-      <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
         {genre.Name}
       </td>
       <td className="whitespace-nowrap px-6 py-4 text-sm font-medium">

--- a/frontend/src/app/components/GenreRow.tsx
+++ b/frontend/src/app/components/GenreRow.tsx
@@ -1,15 +1,30 @@
 'use client'
 
 import type { GenreWithReference } from '@/lib/backend/types/genre'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import Link from 'next/link'
 import type React from 'react'
 
 interface GenreRowProps {
   genre: GenreWithReference
   onDelete: (genreId: number) => Promise<void>
+  isReordering: boolean
 }
 
-const GenreRow: React.FC<GenreRowProps> = ({ genre, onDelete }) => {
+const GenreRow: React.FC<GenreRowProps> = ({
+  genre,
+  onDelete,
+  isReordering,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: genre.ID })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
   const handleDelete = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
     if (confirm('本当にこのジャンルを削除しますか？')) {
@@ -18,7 +33,13 @@ const GenreRow: React.FC<GenreRowProps> = ({ genre, onDelete }) => {
   }
 
   return (
-    <tr className="relative hover:bg-gray-50 dark:hover:bg-gray-700">
+    <tr
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className="hover:bg-gray-50 dark:hover:bg-gray-700"
+    >
       <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
         {genre.DisplayOrder}
       </td>
@@ -27,34 +48,42 @@ const GenreRow: React.FC<GenreRowProps> = ({ genre, onDelete }) => {
       </td>
       <td className="whitespace-nowrap px-6 py-4 text-sm font-medium">
         <div className="flex items-center">
-          <div className="flex flex-1 justify-center">
-            <Link
-              href={`/admin/genres/edit/${genre.ID}`}
-              className="rounded-md bg-indigo-100 px-4 py-2 text-indigo-600 transition-colors duration-200 hover:bg-indigo-200 hover:text-indigo-900 dark:bg-indigo-700 dark:text-white dark:hover:bg-indigo-600 dark:hover:text-indigo-200"
-            >
-              編集
-            </Link>
-          </div>
-          <div className="flex flex-1 justify-center">
-            <div className="group relative">
-              <button
-                onClick={handleDelete}
-                disabled={genre.IsReferenced}
-                className={`rounded-md px-4 py-2 transition-colors duration-200 ${
-                  genre.IsReferenced
-                    ? 'cursor-not-allowed bg-gray-300 text-gray-500 dark:bg-gray-600 dark:text-gray-400'
-                    : 'bg-red-100 text-red-600 hover:bg-red-200 hover:text-red-900 dark:bg-red-700 dark:text-white dark:hover:bg-red-600 dark:hover:text-red-200'
-                }`}
-              >
-                削除
-              </button>
-              {genre.IsReferenced && (
-                <div className="absolute bottom-full right-0 z-10 mb-2 whitespace-nowrap rounded-md bg-gray-700 px-3 py-1 text-xs text-white opacity-0 transition-opacity duration-200 group-hover:opacity-100 dark:bg-gray-200 dark:text-gray-800">
-                  このジャンルは参照されているため削除できません
-                </div>
-              )}
+          {isReordering ? (
+            <div className="flex-1 text-center">
+              <span className="text-gray-500">ドラッグして順序変更</span>
             </div>
-          </div>
+          ) : (
+            <>
+              <div className="flex flex-1 justify-center">
+                <Link
+                  href={`/admin/genres/edit/${genre.ID}`}
+                  className="rounded-md bg-indigo-100 px-4 py-2 text-indigo-600 transition-colors duration-200 hover:bg-indigo-200 hover:text-indigo-900 dark:bg-indigo-700 dark:text-white dark:hover:bg-indigo-600 dark:hover:text-indigo-200"
+                >
+                  編集
+                </Link>
+              </div>
+              <div className="flex flex-1 justify-center">
+                <div className="group relative">
+                  <button
+                    onClick={handleDelete}
+                    disabled={genre.IsReferenced}
+                    className={`rounded-md px-4 py-2 transition-colors duration-200 ${
+                      genre.IsReferenced
+                        ? 'cursor-not-allowed bg-gray-300 text-gray-500 dark:bg-gray-600 dark:text-gray-400'
+                        : 'bg-red-100 text-red-600 hover:bg-red-200 hover:text-red-900 dark:bg-red-700 dark:text-white dark:hover:bg-red-600 dark:hover:text-red-200'
+                    }`}
+                  >
+                    削除
+                  </button>
+                  {genre.IsReferenced && (
+                    <div className="absolute bottom-full right-0 z-10 mb-2 whitespace-nowrap rounded-md bg-gray-700 px-3 py-1 text-xs text-white opacity-0 transition-opacity duration-200 group-hover:opacity-100 dark:bg-gray-200 dark:text-gray-800">
+                      このジャンルは参照されているため削除できません
+                    </div>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
         </div>
       </td>
     </tr>

--- a/frontend/src/app/components/GenreTable.tsx
+++ b/frontend/src/app/components/GenreTable.tsx
@@ -1,45 +1,94 @@
+'use client'
+
 import GenreRow from '@/app/components/GenreRow'
 import type { GenreWithReference } from '@/lib/backend/types/genre'
+import type { DragEndEvent } from '@dnd-kit/core'
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
 import type React from 'react'
 
 interface GenreTableProps {
   genres: GenreWithReference[]
   handleDeleteGenre: (genreId: number) => Promise<void>
+  onGenresReorder: (genres: GenreWithReference[]) => void
+  isReordering: boolean
 }
 
 const GenreTable: React.FC<GenreTableProps> = ({
   genres,
   handleDeleteGenre,
+  onGenresReorder,
+  isReordering,
 }) => {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+
+    if (active.id !== over?.id) {
+      const oldIndex = genres.findIndex((item) => item.ID === active.id)
+      const newIndex = genres.findIndex((item) => item.ID === over?.id)
+      const newGenres = arrayMove(genres, oldIndex, newIndex)
+      onGenresReorder(newGenres)
+    }
+  }
+
   return (
     <div className="flex justify-center">
       <div className="w-full max-w-4xl">
-        <table className="min-w-full overflow-hidden rounded-lg border border-gray-300 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800">
-          <thead className="bg-gray-100 dark:bg-gray-700">
-            <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
-                順番
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
-                ジャンル名
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
-                操作
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
-            {genres
-              .sort((a, b) => a.DisplayOrder - b.DisplayOrder)
-              .map((genre) => (
-                <GenreRow
-                  key={genre.ID}
-                  genre={genre}
-                  onDelete={handleDeleteGenre}
-                />
-              ))}
-          </tbody>
-        </table>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <table className="min-w-full overflow-hidden rounded-lg border border-gray-300 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800">
+            <thead className="bg-gray-100 dark:bg-gray-700">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
+                  順番
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
+                  ジャンル名
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
+                  操作
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
+              <SortableContext
+                items={genres.map((genre) => genre.ID)}
+                strategy={verticalListSortingStrategy}
+              >
+                {genres.map((genre) => (
+                  <GenreRow
+                    key={genre.ID}
+                    genre={genre}
+                    onDelete={handleDeleteGenre}
+                    isReordering={isReordering}
+                  />
+                ))}
+              </SortableContext>
+            </tbody>
+          </table>
+        </DndContext>
       </div>
     </div>
   )

--- a/frontend/src/app/components/GenreTable.tsx
+++ b/frontend/src/app/components/GenreTable.tsx
@@ -50,42 +50,55 @@ const GenreTable: React.FC<GenreTableProps> = ({
     }
   }
 
+  const tableContent = isReordering ? (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={genres.map((genre) => genre.ID)}
+        strategy={verticalListSortingStrategy}
+      >
+        {genres.map((genre) => (
+          <GenreRow
+            key={genre.ID}
+            genre={genre}
+            onDelete={handleDeleteGenre}
+            isReordering={isReordering}
+          />
+        ))}
+      </SortableContext>
+    </DndContext>
+  ) : (
+    genres.map((genre) => (
+      <GenreRow
+        key={genre.ID}
+        genre={genre}
+        onDelete={handleDeleteGenre}
+        isReordering={isReordering}
+      />
+    ))
+  )
+
   return (
     <div className="flex justify-center">
       <div className="w-full max-w-4xl">
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleDragEnd}
-        >
-          <table className="min-w-full overflow-hidden rounded-lg border border-gray-300 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800">
-            <thead className="bg-gray-100 dark:bg-gray-700">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
-                  ジャンル名
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
-                  操作
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
-              <SortableContext
-                items={genres.map((genre) => genre.ID)}
-                strategy={verticalListSortingStrategy}
-              >
-                {genres.map((genre) => (
-                  <GenreRow
-                    key={genre.ID}
-                    genre={genre}
-                    onDelete={handleDeleteGenre}
-                    isReordering={isReordering}
-                  />
-                ))}
-              </SortableContext>
-            </tbody>
-          </table>
-        </DndContext>
+        <table className="min-w-full overflow-hidden rounded-lg border border-gray-300 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800">
+          <thead className="bg-gray-100 dark:bg-gray-700">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
+                ジャンル名
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
+                操作
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
+            {tableContent}
+          </tbody>
+        </table>
       </div>
     </div>
   )

--- a/frontend/src/app/components/GenreTable.tsx
+++ b/frontend/src/app/components/GenreTable.tsx
@@ -62,9 +62,6 @@ const GenreTable: React.FC<GenreTableProps> = ({
             <thead className="bg-gray-100 dark:bg-gray-700">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
-                  順番
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
                   ジャンル名
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">

--- a/frontend/src/app/components/TaskEditor.tsx
+++ b/frontend/src/app/components/TaskEditor.tsx
@@ -61,12 +61,23 @@ const TaskEditor: React.FC<TaskEditorProps> = ({
         </h1>
         <div className="flex gap-4">
           {isReordering ? (
-            <button
-              onClick={saveNewOrder}
-              className="rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600"
-            >
-              保存
-            </button>
+            <>
+              <button
+                onClick={saveNewOrder}
+                className="rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600"
+              >
+                保存
+              </button>
+              <button
+                onClick={() => {
+                  setIsReordering(false)
+                  setTasks(initialTasks) // 元の順序に戻す
+                }}
+                className="rounded bg-gray-500 px-4 py-2 text-white hover:bg-gray-600"
+              >
+                キャンセル
+              </button>
+            </>
           ) : (
             <>
               <button

--- a/frontend/src/app/components/TaskEditor.tsx
+++ b/frontend/src/app/components/TaskEditor.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import type { Task, TaskOrder } from '@/lib/backend/types/task'
+import Link from 'next/link'
+import type React from 'react'
+import { useEffect, useState } from 'react'
+import TaskTable from './TaskTable'
+
+interface TaskEditorProps {
+  tasks: Task[]
+  handleDeleteTask: (taskId: number) => Promise<void>
+  handleUpdateTaskOrders: (taskOrders: TaskOrder[]) => Promise<void>
+}
+
+const TaskEditor: React.FC<TaskEditorProps> = ({
+  tasks: initialTasks,
+  handleDeleteTask,
+  handleUpdateTaskOrders,
+}) => {
+  const [isReordering, setIsReordering] = useState(false)
+  const [tasks, setTasks] = useState(initialTasks)
+
+  useEffect(() => {
+    setTasks(initialTasks)
+  }, [initialTasks])
+
+  const saveNewOrder = async () => {
+    const tasksByGenre = tasks.reduce(
+      (acc, task) => {
+        const genreId = task.GenreID
+        if (!acc[genreId]) {
+          acc[genreId] = []
+        }
+        acc[genreId].push(task)
+        return acc
+      },
+      {} as Record<number, Task[]>,
+    )
+
+    const taskOrders: TaskOrder[] = Object.values(tasksByGenre).flatMap(
+      (genreTasks) =>
+        genreTasks.map((task, index) => ({
+          TaskID: task.ID,
+          NewOrder: index + 1,
+        })),
+    )
+
+    await handleUpdateTaskOrders(taskOrders)
+    setIsReordering(false)
+  }
+
+  const handleTasksReorder = (reorderedTasks: Task[]) => {
+    setTasks(reorderedTasks)
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          課題一覧
+        </h1>
+        <div className="flex gap-4">
+          {isReordering ? (
+            <button
+              onClick={saveNewOrder}
+              className="rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600"
+            >
+              保存
+            </button>
+          ) : (
+            <>
+              <button
+                onClick={() => setIsReordering(true)}
+                className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+              >
+                順番変更
+              </button>
+              <Link
+                href="/admin/tasks/new"
+                className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700"
+              >
+                新規課題作成
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+      <TaskTable
+        tasks={tasks}
+        handleDeleteTask={handleDeleteTask}
+        onTasksReorder={handleTasksReorder}
+        isReordering={isReordering}
+      />
+    </div>
+  )
+}
+
+export default TaskEditor

--- a/frontend/src/app/components/TaskForm.tsx
+++ b/frontend/src/app/components/TaskForm.tsx
@@ -9,12 +9,7 @@ import { useEffect, useState } from 'react'
 interface TaskFormProps {
   genres: Genre[]
   initialTask?: Task
-  onSubmit: (
-    title: string,
-    text: string,
-    genreId: number,
-    displayOrder: number,
-  ) => Promise<void>
+  onSubmit: (title: string, text: string, genreId: number) => Promise<void>
 }
 
 export default function TaskForm({
@@ -26,16 +21,12 @@ export default function TaskForm({
   const [title, setTitle] = useState(initialTask?.Title || '')
   const [text, setText] = useState(initialTask?.Text || '')
   const [genreId, setGenreId] = useState(initialTask?.GenreID || 0)
-  const [displayOrder, setDisplayOrder] = useState(
-    initialTask?.DisplayOrder || 0,
-  )
 
   useEffect(() => {
     if (initialTask) {
       setTitle(initialTask.Title)
       setText(initialTask.Text)
       setGenreId(initialTask.GenreID)
-      setDisplayOrder(initialTask.DisplayOrder)
     }
   }, [initialTask])
 
@@ -47,7 +38,7 @@ export default function TaskForm({
       return
     }
     try {
-      await onSubmit(title, text, genre.ID, displayOrder)
+      await onSubmit(title, text, genre.ID)
       router.push('/admin/tasks')
     } catch (error) {
       console.error('課題の保存中にエラーが発生しました:', error)
@@ -113,29 +104,19 @@ export default function TaskForm({
           onChange={(e) => setText(e.target.value)}
         ></textarea>
       </div>
-      <div>
-        <label
-          htmlFor="displayOrder"
-          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
-        >
-          表示順
-        </label>
-        <input
-          type="number"
-          id="displayOrder"
-          name="displayOrder"
-          value={displayOrder}
-          onChange={(e) => setDisplayOrder(parseInt(e.target.value))}
-          required
-          className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
-        />
-      </div>
-      <div>
+      <div className="space-y-4">
         <button
           type="submit"
           className="flex w-full justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:bg-indigo-700 dark:hover:bg-indigo-600"
         >
           {initialTask ? '更新' : '作成'}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push('/admin/tasks')}
+          className="flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+        >
+          戻る
         </button>
       </div>
     </form>

--- a/frontend/src/app/components/TaskRow.tsx
+++ b/frontend/src/app/components/TaskRow.tsx
@@ -37,9 +37,6 @@ const TaskRow: React.FC<TaskRowProps> = ({ task, onDelete, isReordering }) => {
       className="hover:bg-gray-50 dark:hover:bg-gray-700"
     >
       <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
-        {task.GenreDisplayOrder} - {task.DisplayOrder}
-      </td>
-      <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
         {task.Title}
       </td>
       <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500 dark:text-gray-400">

--- a/frontend/src/app/components/TaskRow.tsx
+++ b/frontend/src/app/components/TaskRow.tsx
@@ -1,15 +1,26 @@
 'use client'
 
 import type { Task } from '@/lib/backend/types/task'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import Link from 'next/link'
 import type React from 'react'
 
 interface TaskRowProps {
   task: Task
   onDelete: (taskId: number) => Promise<void>
+  isReordering: boolean
 }
 
-const TaskRow: React.FC<TaskRowProps> = ({ task, onDelete }) => {
+const TaskRow: React.FC<TaskRowProps> = ({ task, onDelete, isReordering }) => {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: task.ID })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
   const handleOnDelete = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
     if (confirm('本当にこの課題を削除しますか？')) {
@@ -18,7 +29,13 @@ const TaskRow: React.FC<TaskRowProps> = ({ task, onDelete }) => {
   }
 
   return (
-    <tr className="hover:bg-gray-50 dark:hover:bg-gray-700">
+    <tr
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className="hover:bg-gray-50 dark:hover:bg-gray-700"
+    >
       <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
         {task.GenreDisplayOrder} - {task.DisplayOrder}
       </td>
@@ -33,22 +50,30 @@ const TaskRow: React.FC<TaskRowProps> = ({ task, onDelete }) => {
       </td>
       <td className="whitespace-nowrap px-6 py-4 text-sm font-medium">
         <div className="flex items-center">
-          <div className="flex flex-1 justify-center">
-            <Link
-              href={`/admin/tasks/edit/${task.ID}`}
-              className="rounded-md bg-indigo-100 px-4 py-2 text-indigo-600 transition-colors duration-200 hover:bg-indigo-200 hover:text-indigo-900 dark:bg-indigo-700 dark:text-white dark:hover:bg-indigo-600 dark:hover:text-indigo-200"
-            >
-              編集
-            </Link>
-          </div>
-          <div className="flex flex-1 justify-center">
-            <button
-              onClick={handleOnDelete}
-              className="rounded-md bg-red-100 px-4 py-2 text-red-600 transition-colors duration-200 hover:bg-red-200 hover:text-red-900 dark:bg-red-700 dark:text-white dark:hover:bg-red-600 dark:hover:text-red-200"
-            >
-              削除
-            </button>
-          </div>
+          {isReordering ? (
+            <div className="flex-1 text-center">
+              <span className="text-gray-500">ドラッグして順番変更</span>
+            </div>
+          ) : (
+            <>
+              <div className="flex flex-1 justify-center">
+                <Link
+                  href={`/admin/tasks/edit/${task.ID}`}
+                  className="rounded-md bg-indigo-100 px-4 py-2 text-indigo-600 transition-colors duration-200 hover:bg-indigo-200 hover:text-indigo-900 dark:bg-indigo-700 dark:text-white dark:hover:bg-indigo-600 dark:hover:text-indigo-200"
+                >
+                  編集
+                </Link>
+              </div>
+              <div className="flex flex-1 justify-center">
+                <button
+                  onClick={handleOnDelete}
+                  className="rounded-md bg-red-100 px-4 py-2 text-red-600 transition-colors duration-200 hover:bg-red-200 hover:text-red-900 dark:bg-red-700 dark:text-white dark:hover:bg-red-600 dark:hover:text-red-200"
+                >
+                  削除
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </td>
     </tr>

--- a/frontend/src/app/components/TaskRow.tsx
+++ b/frontend/src/app/components/TaskRow.tsx
@@ -13,12 +13,19 @@ interface TaskRowProps {
 }
 
 const TaskRow: React.FC<TaskRowProps> = ({ task, onDelete, isReordering }) => {
-  const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({ id: task.ID })
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: task.ID })
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
+    cursor: isReordering ? (isDragging ? 'grabbing' : 'grab') : 'default',
   }
 
   const handleOnDelete = async (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -34,7 +41,7 @@ const TaskRow: React.FC<TaskRowProps> = ({ task, onDelete, isReordering }) => {
       style={style}
       {...attributes}
       {...listeners}
-      className="hover:bg-gray-50 dark:hover:bg-gray-700"
+      className={isReordering ? 'hover:bg-gray-50 dark:hover:bg-gray-700' : ''}
     >
       <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
         {task.Title}

--- a/frontend/src/app/components/TaskTable.tsx
+++ b/frontend/src/app/components/TaskTable.tsx
@@ -61,9 +61,6 @@ const TaskTable: React.FC<TaskTableProps> = ({
           <thead className="bg-gray-100 dark:bg-gray-700">
             <tr>
               <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
-                順番
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
                 タイトル
               </th>
               <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">

--- a/frontend/src/app/components/TaskTable.tsx
+++ b/frontend/src/app/components/TaskTable.tsx
@@ -50,47 +50,60 @@ const TaskTable: React.FC<TaskTableProps> = ({
     }
   }
 
+  const tableContent = isReordering ? (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={tasks.map((task) => task.ID)}
+        strategy={verticalListSortingStrategy}
+      >
+        {tasks.map((task) => (
+          <TaskRow
+            key={task.ID}
+            task={task}
+            onDelete={handleDeleteTask}
+            isReordering={isReordering}
+          />
+        ))}
+      </SortableContext>
+    </DndContext>
+  ) : (
+    tasks.map((task) => (
+      <TaskRow
+        key={task.ID}
+        task={task}
+        onDelete={handleDeleteTask}
+        isReordering={isReordering}
+      />
+    ))
+  )
+
   return (
     <div className="w-full max-w-4xl">
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-      >
-        <table className="min-w-full overflow-hidden rounded-lg border border-gray-300 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800">
-          <thead className="bg-gray-100 dark:bg-gray-700">
-            <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
-                タイトル
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
-                ジャンル
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
-                本文
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
-                操作
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
-            <SortableContext
-              items={tasks.map((task) => task.ID)}
-              strategy={verticalListSortingStrategy}
-            >
-              {tasks.map((task) => (
-                <TaskRow
-                  key={task.ID}
-                  task={task}
-                  onDelete={handleDeleteTask}
-                  isReordering={isReordering}
-                />
-              ))}
-            </SortableContext>
-          </tbody>
-        </table>
-      </DndContext>
+      <table className="min-w-full overflow-hidden rounded-lg border border-gray-300 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800">
+        <thead className="bg-gray-100 dark:bg-gray-700">
+          <tr>
+            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
+              タイトル
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
+              ジャンル
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
+              本文
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
+              操作
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
+          {tableContent}
+        </tbody>
+      </table>
     </div>
   )
 }

--- a/frontend/src/lib/backend/genre.ts
+++ b/frontend/src/lib/backend/genre.ts
@@ -1,4 +1,4 @@
-import type { Genre, GenreWithReference } from './types/genre'
+import type { Genre, GenreOrder, GenreWithReference } from './types/genre'
 
 export async function getGenres(): Promise<GenreWithReference[]> {
   const response = await fetch(`${process.env.BACKEND_URL}/genres`, {
@@ -46,5 +46,17 @@ export async function updateGenre(
 export async function deleteGenre(genreId: number): Promise<void> {
   await fetch(`${process.env.BACKEND_URL}/genres/${genreId}`, {
     method: 'DELETE',
+  })
+}
+
+export async function updateGenreOrders(
+  genreOrders: GenreOrder[],
+): Promise<void> {
+  await fetch(`${process.env.BACKEND_URL}/genres/order`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(genreOrders),
   })
 }

--- a/frontend/src/lib/backend/genre.ts
+++ b/frontend/src/lib/backend/genre.ts
@@ -16,30 +16,26 @@ export async function getGenre(genreId: number): Promise<Genre> {
   return genre
 }
 
-export async function createGenre(
-  genreName: string,
-  displayOrder: number,
-): Promise<void> {
+export async function createGenre(genreName: string): Promise<void> {
   await fetch(`${process.env.BACKEND_URL}/genres`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ Name: genreName, DisplayOrder: displayOrder }),
+    body: JSON.stringify({ Name: genreName }),
   })
 }
 
 export async function updateGenre(
   genreId: number,
   genreName: string,
-  displayOrder: number,
 ): Promise<void> {
   await fetch(`${process.env.BACKEND_URL}/genres/${genreId}`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ Name: genreName, DisplayOrder: displayOrder }),
+    body: JSON.stringify({ Name: genreName }),
   })
 }
 

--- a/frontend/src/lib/backend/task.ts
+++ b/frontend/src/lib/backend/task.ts
@@ -1,4 +1,4 @@
-import type { Task } from '@/lib/backend/types/task'
+import type { Task, TaskOrder } from '@/lib/backend/types/task'
 
 export async function getTasks(): Promise<Task[]> {
   const response = await fetch(`${process.env.BACKEND_URL}/tasks`)
@@ -58,5 +58,13 @@ export async function updateTask(
 export async function deleteTask(taskId: number): Promise<void> {
   await fetch(`${process.env.BACKEND_URL}/tasks/${taskId}`, {
     method: 'DELETE',
+  })
+}
+
+export async function updateTaskOrders(taskOrders: TaskOrder[]): Promise<void> {
+  await fetch(`${process.env.BACKEND_URL}/tasks/order`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(taskOrders),
   })
 }

--- a/frontend/src/lib/backend/task.ts
+++ b/frontend/src/lib/backend/task.ts
@@ -18,7 +18,6 @@ export async function createTask(
   title: string,
   text: string,
   genreId: number,
-  displayOrder: number,
 ): Promise<void> {
   await fetch(`${process.env.BACKEND_URL}/tasks`, {
     method: 'POST',
@@ -29,7 +28,6 @@ export async function createTask(
       Title: title,
       Text: text,
       GenreID: genreId,
-      DisplayOrder: displayOrder,
     }),
   })
 }
@@ -39,7 +37,6 @@ export async function updateTask(
   title: string,
   text: string,
   genreId: number,
-  displayOrder: number,
 ): Promise<void> {
   await fetch(`${process.env.BACKEND_URL}/tasks/${taskId}`, {
     method: 'PATCH',
@@ -50,7 +47,6 @@ export async function updateTask(
       Title: title,
       Text: text,
       GenreID: genreId,
-      DispalyOrder: displayOrder,
     }),
   })
 }

--- a/frontend/src/lib/backend/types/genre.ts
+++ b/frontend/src/lib/backend/types/genre.ts
@@ -7,3 +7,8 @@ export interface Genre {
 export interface GenreWithReference extends Genre {
   IsReferenced: boolean
 }
+
+export interface GenreOrder {
+  GenreID: number
+  NewOrder: number
+}

--- a/frontend/src/lib/backend/types/task.ts
+++ b/frontend/src/lib/backend/types/task.ts
@@ -7,3 +7,8 @@ export interface Task {
   Text: string
   DisplayOrder: number
 }
+
+export interface TaskOrder {
+  TaskID: number
+  NewOrder: number
+}


### PR DESCRIPTION
https://github.com/cashev/PrAhaChallenge-Team/issues/8
以下ライブラリを利用してドラッグアンドドロップで順序を更新  

新規追加時はその最大値をバックエンドで取得し、最大値+1を設定する。

課題,ジャンルテーブルから順番の列を削除  
課題,ジャンルフォームから表示順の入力欄を削除  

ライブラリ
https://dndkit.com/

