### PR TITLE
問い合わせ一覧画面を改善

### DIFF
--- a/frontend/src/app/admin/supports/[id]/page.tsx
+++ b/frontend/src/app/admin/supports/[id]/page.tsx
@@ -14,6 +14,11 @@ export default async function StatusChangeRequestDetailPage({
   const requestId = parseInt(params.id)
   const request = await getStatusChangeRequest(requestId)
 
+  const backUrl =
+    request.Status === '対応済'
+      ? '/admin/supports?tab=対応済み'
+      : '/admin/supports'
+
   const handleProcess = async () => {
     'use server'
     await processStatusChangeRequest(requestId)
@@ -28,7 +33,7 @@ export default async function StatusChangeRequestDetailPage({
           問い合わせ詳細
         </h1>
         <Link
-          href="/admin/supports"
+          href={backUrl}
           className="rounded-md bg-gray-100 px-4 py-2 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
         >
           一覧へ戻る
@@ -42,14 +47,18 @@ export default async function StatusChangeRequestDetailPage({
               受講生情報
             </h2>
             <div className="mt-2 space-y-2">
-              <p className="text-gray-700 dark:text-gray-300">
-                <span className="font-semibold">期：</span>
-                {request.Season}期
-              </p>
-              <p className="text-gray-700 dark:text-gray-300">
-                <span className="font-semibold">チーム：</span>
-                {request.TeamName}
-              </p>
+              {request.Season !== 0 && (
+                <p className="text-gray-700 dark:text-gray-300">
+                  <span className="font-semibold">期：</span>
+                  {request.Season}期
+                </p>
+              )}
+              {request.TeamName && (
+                <p className="text-gray-700 dark:text-gray-300">
+                  <span className="font-semibold">チーム：</span>
+                  {request.TeamName}
+                </p>
+              )}
               <p className="text-gray-700 dark:text-gray-300">
                 <span className="font-semibold">名前：</span>
                 {request.StudentName}

--- a/frontend/src/app/admin/supports/page.tsx
+++ b/frontend/src/app/admin/supports/page.tsx
@@ -3,6 +3,7 @@ import {
   getProcessedStatusChangeRequests,
   getUnprocessedStatusChangeRequests,
 } from '@/lib/backend/contact'
+import { Suspense } from 'react'
 
 export default async function ContactsPage() {
   const unprocessedRequests = await getUnprocessedStatusChangeRequests()
@@ -15,10 +16,12 @@ export default async function ContactsPage() {
       </h1>
       <div className="overflow-hidden rounded-lg bg-white shadow dark:bg-gray-800">
         <div className="px-4 py-5 sm:p-6">
-          <StatusChangeRequestList
-            unprocessedRequests={unprocessedRequests}
-            processedRequests={processedRequests}
-          />
+          <Suspense fallback={<div>読み込み中...</div>}>
+            <StatusChangeRequestList
+              unprocessedRequests={unprocessedRequests}
+              processedRequests={processedRequests}
+            />
+          </Suspense>
         </div>
       </div>
     </div>

--- a/frontend/src/app/components/StatusChangeRequestList.tsx
+++ b/frontend/src/app/components/StatusChangeRequestList.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import type { StatusChangeRequest } from '@/lib/backend/types/contact-type'
-import { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
 
 interface StatusChangeRequestListProps {
   unprocessedRequests: StatusChangeRequest[]
@@ -12,7 +13,27 @@ export default function StatusChangeRequestList({
   unprocessedRequests,
   processedRequests,
 }: StatusChangeRequestListProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
   const [activeTab, setActiveTab] = useState<'未対応' | '対応済み'>('未対応')
+
+  useEffect(() => {
+    const tab = searchParams.get('tab')
+    if (tab === '対応済み') {
+      setActiveTab('対応済み')
+    }
+  }, [searchParams])
+
+  const handleTabChange = (tab: '未対応' | '対応済み') => {
+    setActiveTab(tab)
+    const params = new URLSearchParams(searchParams)
+    if (tab === '対応済み') {
+      params.set('tab', '対応済み')
+    } else {
+      params.delete('tab')
+    }
+    router.replace(`/admin/supports?${params.toString()}`)
+  }
 
   const renderRequestTable = (requests: StatusChangeRequest[]) => (
     <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
@@ -89,7 +110,7 @@ export default function StatusChangeRequestList({
                   ? 'border-blue-600 text-blue-600 dark:border-blue-500 dark:text-blue-500'
                   : 'border-transparent hover:border-gray-300 hover:text-gray-600 dark:hover:text-gray-300'
               }`}
-              onClick={() => setActiveTab('未対応')}
+              onClick={() => handleTabChange('未対応')}
             >
               未対応 ({unprocessedRequests.length})
             </button>
@@ -101,7 +122,7 @@ export default function StatusChangeRequestList({
                   ? 'border-blue-600 text-blue-600 dark:border-blue-500 dark:text-blue-500'
                   : 'border-transparent hover:border-gray-300 hover:text-gray-600 dark:hover:text-gray-300'
               }`}
-              onClick={() => setActiveTab('対応済み')}
+              onClick={() => handleTabChange('対応済み')}
             >
               対応済み ({processedRequests.length})
             </button>


### PR DESCRIPTION
詳細から一覧画面に戻るとき、開いていたタブを開く.


問い合わせ用にサンプルデータを追加

以下エラーを修正
```
 ⨯ useSearchParams() should be wrapped in a suspense boundary at page "/admin/supports". Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout
    at a (/tmp/build_b0fdde6b/.next/server/chunks/127.js:1:31091)
    at s (/tmp/build_b0fdde6b/.next/server/chunks/127.js:1:42073)
    at d (/tmp/build_b0fdde6b/.next/server/app/admin/supports/page.js:1:2984)
    at nj (/tmp/build_b0fdde6b/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:46251)
    at nM (/tmp/build_b0fdde6b/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:47571)
    at nM (/tmp/build_b0fdde6b/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:61546)
    at nN (/tmp/build_b0fdde6b/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:64546)
    at nB (/tmp/build_b0fdde6b/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:67538)
    at nM (/tmp/build_b0fdde6b/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:58560)
    at nN (/tmp/build_b0fdde6b/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:64546)
Error occurred prerendering page "/admin/supports". Read more: https://nextjs.org/docs/messages/prerender-error
          Generating static pages (9/19) 
          Generating static pages (14/19) 
        ✓ Generating static pages (19/19)
> Export encountered errors on following paths:
	/admin/supports/page: /admin/supports
-----> Build failed
```